### PR TITLE
CRUD-1 added changes to check for just a grave and remove JK index

### DIFF
--- a/KAIS.Interactive.DSPC_EXPLORER/KAIS.Interactive.DSPC_EXPLORER.API/Controllers/DowExplorerController.cs
+++ b/KAIS.Interactive.DSPC_EXPLORER/KAIS.Interactive.DSPC_EXPLORER.API/Controllers/DowExplorerController.cs
@@ -88,7 +88,7 @@ namespace KAIS.Interactive.DSPC_EXPLORER.API.Controllers
         }
 
         [HttpPost("kais/api/dspc_explorer/addnewgraveowner")]
-        public async Task<IActionResult> AddNewGraveOwner(string subId, string jKIndex, string graveReferenceCode, 
+        public async Task<IActionResult> AddNewGraveOwner(string subId, string graveReferenceCode, 
             string section, int graveRow, int graveDepth, string graveSize, string graveLocation, bool graveHeadStone, string graveOwnerName, string graveOwnerAddress, string remarks)
         {
             try
@@ -100,7 +100,6 @@ namespace KAIS.Interactive.DSPC_EXPLORER.API.Controllers
                 GraveOwner graveOwner = new GraveOwner
                 {
                     SubId = subId,
-                    JkIndex = jKIndex,
                     GraveReferenceCode = graveReferenceCode,
                     GraveRow = graveRow,
                     GraveDepth = graveDepth,

--- a/KAIS.Interactive.DSPC_EXPLORER/KAIS.Interactive.DSPC_EXPLORER.Infrastructure/DSPC_Repository.cs
+++ b/KAIS.Interactive.DSPC_EXPLORER/KAIS.Interactive.DSPC_EXPLORER.Infrastructure/DSPC_Repository.cs
@@ -20,33 +20,27 @@ namespace KAIS.Interactive.DSPC_EXPLORER.Infrastructure
         public async Task<bool> AddNewRegistrar(Registrar registrar)
         {
 
-            var data = await (from person in _dbContext.Registrars
-                              from grave in _dbContext.GraveOwners
-                              from section in _dbContext.Sections
+            var data = await (from grave in _dbContext.GraveOwners
                               where grave.GraveReferenceCode == registrar.GraveOwner.GraveReferenceCode
-                              select new Registrar
-                              {
-                                  Id = person.Id,
-                                  GraveOwner = new GraveOwner
+                              select new GraveOwner
                                   {
                                       Id = grave.Id,
                                       GraveSize = grave.GraveSize,
                                       GraveReferenceCode = grave.GraveReferenceCode,
                                       Section = new Section
                                       {
-                                          Id = section.Id,
+                                          Id = grave.Section.Id,
                                       },
-                                  },
-                              }).FirstOrDefaultAsync();
+                                  }).FirstOrDefaultAsync();
 
             if (data != null)
             {
-                SizeOfGrave graveSizeEnum = (SizeOfGrave)Enum.Parse(typeof(SizeOfGrave), data.GraveOwner.GraveSize);
+                SizeOfGrave graveSizeEnum = (SizeOfGrave)Enum.Parse(typeof(SizeOfGrave), data.GraveSize);
                 int graveSize = GeneralEnums.GetGraveSizeFromLetter(graveSizeEnum);
 
                 if (graveSize > 0)
                     {
-                        int currentPeopleSize = GetRegistrarsByGraveReferenceCode(data.GraveOwner.GraveReferenceCode).Result.Count;
+                        int currentPeopleSize = GetRegistrarsByGraveReferenceCode(data.GraveReferenceCode).Result.Count;
 
                         if (currentPeopleSize < graveSize || registrar.Age < 11 || (registrar.AdditionalComments != null && registrar.AdditionalComments.ToUpper() == "JK"))
                         {
@@ -197,7 +191,6 @@ namespace KAIS.Interactive.DSPC_EXPLORER.Infrastructure
                           {
                               Id = grave.Id,
                               SubId = grave.SubId,
-                              JkIndex = grave.JkIndex,
                               GraveReferenceCode = grave.GraveReferenceCode,
                               GraveRow = grave.GraveRow,
                               GraveDepth = grave.GraveDepth,
@@ -240,7 +233,6 @@ namespace KAIS.Interactive.DSPC_EXPLORER.Infrastructure
                               {
                                   Id = person.GraveOwner.Id,
                                   SubId = person.GraveOwner.SubId,
-                                  JkIndex = person.GraveOwner.JkIndex,
                                   GraveReferenceCode = person.GraveOwner.GraveReferenceCode,
                                   GraveRow = person.GraveOwner.GraveRow,
                                   GraveDepth = person.GraveOwner.GraveDepth,
@@ -291,7 +283,6 @@ namespace KAIS.Interactive.DSPC_EXPLORER.Infrastructure
                               {
                                   Id = person.GraveOwner.Id,
                                   SubId = person.GraveOwner.SubId,
-                                  JkIndex = person.GraveOwner.JkIndex,
                                   GraveReferenceCode = person.GraveOwner.GraveReferenceCode,
                                   GraveRow = person.GraveOwner.GraveRow,
                                   GraveDepth = person.GraveOwner.GraveDepth,

--- a/KAIS.Interactive.DSPC_EXPLORER/KAIS.Interactive.DSPC_EXPLORER.Infrastructure/Migrations/20200422205557_initialCreation.Designer.cs
+++ b/KAIS.Interactive.DSPC_EXPLORER/KAIS.Interactive.DSPC_EXPLORER.Infrastructure/Migrations/20200422205557_initialCreation.Designer.cs
@@ -10,8 +10,8 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace KAIS.Interactive.DSPC_EXPLORER.Infrastructure.Migrations
 {
     [DbContext(typeof(DSPC_ExplorerDbContext))]
-    [Migration("20200413032329_InitialCreation")]
-    partial class InitialCreation
+    [Migration("20200422205557_initialCreation")]
+    partial class initialCreation
     {
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
@@ -43,11 +43,9 @@ namespace KAIS.Interactive.DSPC_EXPLORER.Infrastructure.Migrations
 
                     b.Property<string>("GraveSize");
 
-                    b.Property<string>("JkIndex");
-
                     b.Property<string>("Remarks");
 
-                    b.Property<int>("SectionId");
+                    b.Property<int?>("SectionId");
 
                     b.Property<string>("SubId");
 
@@ -153,8 +151,7 @@ namespace KAIS.Interactive.DSPC_EXPLORER.Infrastructure.Migrations
                 {
                     b.HasOne("KAIS.Interactive.DSPC_EXPLORER.Infrastructure.Model.Section", "Section")
                         .WithMany()
-                        .HasForeignKey("SectionId")
-                        .OnDelete(DeleteBehavior.Cascade);
+                        .HasForeignKey("SectionId");
                 });
 
             modelBuilder.Entity("KAIS.Interactive.DSPC_EXPLORER.Infrastructure.Model.Registrar", b =>

--- a/KAIS.Interactive.DSPC_EXPLORER/KAIS.Interactive.DSPC_EXPLORER.Infrastructure/Migrations/20200422205557_initialCreation.cs
+++ b/KAIS.Interactive.DSPC_EXPLORER/KAIS.Interactive.DSPC_EXPLORER.Infrastructure/Migrations/20200422205557_initialCreation.cs
@@ -4,7 +4,7 @@ using Microsoft.EntityFrameworkCore.Migrations;
 
 namespace KAIS.Interactive.DSPC_EXPLORER.Infrastructure.Migrations
 {
-    public partial class InitialCreation : Migration
+    public partial class initialCreation : Migration
     {
         protected override void Up(MigrationBuilder migrationBuilder)
         {
@@ -46,9 +46,7 @@ namespace KAIS.Interactive.DSPC_EXPLORER.Infrastructure.Migrations
                     Id = table.Column<int>(nullable: false)
                         .Annotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn),
                     SubId = table.Column<string>(nullable: true),
-                    JkIndex = table.Column<string>(nullable: true),
                     GraveReferenceCode = table.Column<string>(nullable: true),
-                    SectionId = table.Column<int>(nullable: false),
                     GraveRow = table.Column<int>(nullable: false),
                     GraveDepth = table.Column<int>(nullable: false),
                     GraveSize = table.Column<string>(nullable: true),
@@ -56,7 +54,8 @@ namespace KAIS.Interactive.DSPC_EXPLORER.Infrastructure.Migrations
                     GraveHeadStone = table.Column<bool>(nullable: false),
                     GraveOwnerName = table.Column<string>(nullable: true),
                     GraveOwnerAddress = table.Column<string>(nullable: true),
-                    Remarks = table.Column<string>(nullable: true)
+                    Remarks = table.Column<string>(nullable: true),
+                    SectionId = table.Column<int>(nullable: true)
                 },
                 constraints: table =>
                 {
@@ -66,7 +65,7 @@ namespace KAIS.Interactive.DSPC_EXPLORER.Infrastructure.Migrations
                         column: x => x.SectionId,
                         principalTable: "Sections",
                         principalColumn: "Id",
-                        onDelete: ReferentialAction.Cascade);
+                        onDelete: ReferentialAction.Restrict);
                 });
 
             migrationBuilder.CreateTable(

--- a/KAIS.Interactive.DSPC_EXPLORER/KAIS.Interactive.DSPC_EXPLORER.Infrastructure/Migrations/DSPC_ExplorerDbContextModelSnapshot.cs
+++ b/KAIS.Interactive.DSPC_EXPLORER/KAIS.Interactive.DSPC_EXPLORER.Infrastructure/Migrations/DSPC_ExplorerDbContextModelSnapshot.cs
@@ -41,11 +41,9 @@ namespace KAIS.Interactive.DSPC_EXPLORER.Infrastructure.Migrations
 
                     b.Property<string>("GraveSize");
 
-                    b.Property<string>("JkIndex");
-
                     b.Property<string>("Remarks");
 
-                    b.Property<int>("SectionId");
+                    b.Property<int?>("SectionId");
 
                     b.Property<string>("SubId");
 
@@ -151,8 +149,7 @@ namespace KAIS.Interactive.DSPC_EXPLORER.Infrastructure.Migrations
                 {
                     b.HasOne("KAIS.Interactive.DSPC_EXPLORER.Infrastructure.Model.Section", "Section")
                         .WithMany()
-                        .HasForeignKey("SectionId")
-                        .OnDelete(DeleteBehavior.Cascade);
+                        .HasForeignKey("SectionId");
                 });
 
             modelBuilder.Entity("KAIS.Interactive.DSPC_EXPLORER.Infrastructure.Model.Registrar", b =>

--- a/KAIS.Interactive.DSPC_EXPLORER/KAIS.Interactive.DSPC_EXPLORER.Infrastructure/Model/GraveOwner.cs
+++ b/KAIS.Interactive.DSPC_EXPLORER/KAIS.Interactive.DSPC_EXPLORER.Infrastructure/Model/GraveOwner.cs
@@ -8,7 +8,6 @@ namespace KAIS.Interactive.DSPC_EXPLORER.Infrastructure.Model
         [Key]
         public int Id { get; set; }
         public string SubId { get; set; }
-        public string JkIndex { get; set; }
         [ForeignKey("GraveReferenceCode")]
         public string GraveReferenceCode { get; set; }
         public int GraveRow { get; set; }


### PR DESCRIPTION
This is a change to the database when adding a new person for only the grave, as it fails if the database is empty for a person in this grave already, so it removes an unneeded check so you can use it correctly.

I have also rebuilt the initial migration to remove the JKIndex from the registrar table and updated the CRUD stuff.

@abdulfs2018 , please recreate the database new and blank and run Update-database then use the CRUD to create a new section, grave and registrar in this order to test it works without the JK index column I have removed here